### PR TITLE
Fix to_s method on Bitmap when checking if higher bits are set

### DIFF
--- a/lib/iso8583/bitmap.rb
+++ b/lib/iso8583/bitmap.rb
@@ -73,7 +73,7 @@ module ISO8583
     #	01001100110000011010110110010100100110011000001101011011001010
     def to_s
       #check whether any `high` bits are set
-      ret           = (65..128).one? {|bit| self[bit]}
+      ret           = (65..128).any? {|bit| self[bit]}
       high, @bmp[0] = ret ? [128, true] : [64, false]
 
       str = ""


### PR DESCRIPTION
When checking if higher bits the correct method to use is "any?".
*The method returns true if the block ever returns a value other than false or nil.*
On the other hand, the "one?" returns true if there is exactly one "true" value.