### PR TITLE
Fix padding in fields preventing octal interpretation instead of integer

### DIFF
--- a/lib/iso8583/fields.rb
+++ b/lib/iso8583/fields.rb
@@ -45,7 +45,7 @@ module ISO8583
   LL.length  = 2
   LL.codec   = ASCII_Number
   LL.padding = lambda {|value|
-    sprintf("%02d", value)
+    sprintf("%02d", value.to_i)
   }
   # Special form to de/encode variable length indicators, three bytes ASCII numerals
   LLL         = Field.new
@@ -53,7 +53,7 @@ module ISO8583
   LLL.length  = 3
   LLL.codec   = ASCII_Number
   LLL.padding = lambda {|value|
-    sprintf("%03d", value)
+    sprintf("%03d", value.to_i)
   }
 
   LL_BCD        = BCDField.new
@@ -110,7 +110,7 @@ module ISO8583
   N = Field.new
   N.codec = ASCII_Number
   N.padding = lambda {|val, len|
-    sprintf("%0#{len}d", val)
+    sprintf("%0#{len}d", val.to_i)
   }
 
   N_BCD = BCDField.new


### PR DESCRIPTION
Use caution when using sprintf, it may interpret input as an octal instead of the real type that you want to use.
Example:
 sprintf("%04d", "077")
=> "0063"
 sprintf("%04d", "078")
=> ArgumentError: invalid value for Integer(): "078"